### PR TITLE
Blockstats subscription refactoring

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,10 @@
 mod evm;
+mod stats;
 mod wasm;
 
 // export for use by contract! macro
 use clap::Parser;
+pub use stats::{collect_block_stats, BlockInfo};
 pub use wasm::{InkConstructor, InkMessage};
 
 #[derive(Debug, Parser)]

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -12,33 +12,31 @@ pub struct BlockInfo {
 /// `remaining_hashes` have been received.
 pub fn collect_block_stats<'a>(
     client: &'a OnlineClient<DefaultConfig>,
-    block_stats: impl TryStream<Ok = blockstats::BlockStats, Error = Error> + Unpin + 'a,
+    block_stats: impl TryStream<Ok = blockstats::BlockStats, Error = Error> + 'a,
     mut remaining_hashes: HashSet<sp_core::H256>,
-) -> impl TryStream<Ok = BlockInfo, Error = color_eyre::Report> + Unpin + 'a {
-    Box::pin(
-        block_stats
-            .map_err(|e| color_eyre::eyre::eyre!("Block stats subscription error: {e:?}"))
-            .and_then(|stats| {
-                tracing::debug!("{stats:?}");
-                let client = client.clone();
-                async move {
-                    let block = client.rpc().block(Some(stats.hash)).await?;
-                    let extrinsics = block
-                        .unwrap_or_else(|| panic!("block {} not found", stats.hash))
-                        .block
-                        .extrinsics
-                        .iter()
-                        .map(BlakeTwo256::hash_of)
-                        .collect();
-                    Ok(BlockInfo { extrinsics, stats })
-                }
-            })
-            .try_take_while(move |block_info| {
-                for xt in &block_info.extrinsics {
-                    remaining_hashes.remove(xt);
-                }
-                let some_remaining_txs = !remaining_hashes.is_empty();
-                future::ready(Ok(some_remaining_txs))
-            }),
-    )
+) -> impl TryStream<Ok = BlockInfo, Error = color_eyre::Report> + '_ {
+    block_stats
+        .map_err(|e| color_eyre::eyre::eyre!("Block stats subscription error: {e:?}"))
+        .and_then(|stats| {
+            tracing::debug!("{stats:?}");
+            let client = client.clone();
+            async move {
+                let block = client.rpc().block(Some(stats.hash)).await?;
+                let extrinsics = block
+                    .unwrap_or_else(|| panic!("block {} not found", stats.hash))
+                    .block
+                    .extrinsics
+                    .iter()
+                    .map(BlakeTwo256::hash_of)
+                    .collect();
+                Ok(BlockInfo { extrinsics, stats })
+            }
+        })
+        .try_take_while(move |block_info| {
+            for xt in &block_info.extrinsics {
+                remaining_hashes.remove(xt);
+            }
+            let some_remaining_txs = !remaining_hashes.is_empty();
+            future::ready(Ok(some_remaining_txs))
+        })
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -34,10 +34,10 @@ pub fn collect_block_stats<'a>(
                 }
             })
             .try_take_while(move |block_info| {
-                let some_remaining_txs = !remaining_hashes.is_empty();
                 for xt in &block_info.extrinsics {
                     remaining_hashes.remove(xt);
                 }
+                let some_remaining_txs = !remaining_hashes.is_empty();
                 future::ready(Ok(some_remaining_txs))
             }),
     )

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,0 +1,44 @@
+use futures::{future, TryStream, TryStreamExt};
+use sp_runtime::traits::{BlakeTwo256, Hash as _};
+use std::collections::HashSet;
+use subxt::{Error, OnlineClient, PolkadotConfig as DefaultConfig};
+
+pub struct BlockInfo {
+    pub stats: blockstats::BlockStats,
+    pub extrinsics: Vec<sp_core::H256>,
+}
+
+/// Subscribes to block stats, printing the output to the console. Completes once *all* hashes in
+/// `remaining_hashes` have been received.
+pub fn collect_block_stats<'a>(
+    client: &'a OnlineClient<DefaultConfig>,
+    block_stats: impl TryStream<Ok = blockstats::BlockStats, Error = Error> + Unpin + 'a,
+    mut remaining_hashes: HashSet<sp_core::H256>,
+) -> impl TryStream<Ok = BlockInfo, Error = color_eyre::Report> + Unpin + 'a {
+    Box::pin(
+        block_stats
+            .map_err(|e| color_eyre::eyre::eyre!("Block stats subscription error: {e:?}"))
+            .and_then(|stats| {
+                tracing::debug!("{stats:?}");
+                let client = client.clone();
+                async move {
+                    let block = client.rpc().block(Some(stats.hash)).await?;
+                    let extrinsics = block
+                        .unwrap_or_else(|| panic!("block {} not found", stats.hash))
+                        .block
+                        .extrinsics
+                        .iter()
+                        .map(BlakeTwo256::hash_of)
+                        .collect();
+                    Ok(BlockInfo { extrinsics, stats })
+                }
+            })
+            .try_take_while(move |block_info| {
+                let some_remaining_txs = !remaining_hashes.is_empty();
+                for xt in &block_info.extrinsics {
+                    remaining_hashes.remove(xt);
+                }
+                future::ready(Ok(some_remaining_txs))
+            }),
+    )
+}


### PR DESCRIPTION
1. Removes duplication of subscription logic
2. Completes subscription once all extrinsic hashes have been included in blocks. Previously it would complete only in the next block, which does not come with the instant seal engine.