### PR TITLE
Replace TPS with sTPS stats

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -161,7 +161,7 @@ jobs:
           STATS=$(./run.sh -- ${{ matrix.type }} ${{ matrix.contract }} ${TEST_PARAMS})
           BLOCKS=$(echo ${STATS} | grep -o 'Total Blocks: [0-9]*' | awk '{print $3}')
           EXTRINSICS=$(echo ${STATS} | grep -o 'Total Extrinsics: [0-9]*' | awk '{print $3}')
-          TPS=$(echo ${STATS} | grep -o 'TPS: [0-9]*' | awk '{print $2}')
+          TPS=$(echo ${STATS} | grep -o 'sTPS: [0-9]*' | awk '{print $2}')
           echo "Blocks: ${BLOCKS}"
           echo "Extrinsics: ${EXTRINSICS}"
           echo "TPS: ${TPS}"

--- a/src/evm/runner.rs
+++ b/src/evm/runner.rs
@@ -224,6 +224,20 @@ impl MoonbeamRunner {
         Ok(tx_hashes)
     }
 
+    async fn get_block_time_stamp(
+        client: OnlineClient<DefaultConfig>,
+        block_hash: sp_core::H256,
+    ) -> color_eyre::Result<u64> {
+        let storage_timestamp_storage_addr = api::storage().timestamp().now();
+        let time_stamp = client
+            .storage()
+            .at(block_hash)
+            .fetch(&storage_timestamp_storage_addr)
+            .await?
+            .unwrap();
+        Ok(time_stamp)
+    }
+
     /// Call each contract instance `call_count` times. Wait for all txs to be included in a block
     /// before returning.
     pub async fn run(
@@ -277,10 +291,18 @@ impl MoonbeamRunner {
             .map(|hash| sp_core::H256::from_slice(hash.as_ref()))
             .collect();
 
-        let wait_for_txs = crate::collect_block_stats(block_stats, remaining_hashes, |hash| {
-            let client = self.api.client.clone();
-            Self::get_eth_hashes_from_events_in_block(client, hash)
-        });
+        let wait_for_txs = crate::collect_block_stats(
+            block_stats,
+            remaining_hashes,
+            |hash| {
+                let client = self.api.client.clone();
+                Self::get_eth_hashes_from_events_in_block(client, hash)
+            },
+            |hash| {
+                let client: OnlineClient<DefaultConfig> = self.api.client.clone();
+                Self::get_block_time_stamp(client, hash)
+            },
+        );
 
         Ok(wait_for_txs)
     }

--- a/src/integration_tests.rs
+++ b/src/integration_tests.rs
@@ -26,7 +26,7 @@ fn is_match(stdout: &str, pattern: &str) -> bool {
 }
 
 const SMART_BENCH_STATS_PATTERN: &str = r"[0-9]+: PoV Size=[0-9]+KiB\([0-9]+%\) Weight RefTime=[0-9]+ms\([0-9]+%\) Weight ProofSize=[0-9]+KiB\([0-9]+%\) Witness=[0-9]+KiB Block=[0-9]+KiB NumExtrinsics=[0-9]+";
-const SMART_BENCH_LAST_LINE_PATTERN: &str = r"TPS: \d+(\.\d+)?";
+const SMART_BENCH_LAST_LINE_PATTERN: &str = r"sTPS: \d+(\.\d+)?";
 const CONTRACTS_NODE_WASM: &str = "substrate-contracts-node";
 const CONTRACTS_NODE_EVM: &str = "moonbeam";
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -71,7 +71,7 @@ pub async fn print_block_info(
             total_blocks += 1;
             if time_diff.is_none() {
                 if let Some(ts) = time_stamp {
-                    time_diff = Some(block.time_stamp - ts)
+                    time_diff = Some((block.time_stamp - ts) as f64 / 1000.0)
                 } else {
                     time_stamp = Some(block.time_stamp)
                 }
@@ -82,16 +82,17 @@ pub async fn print_block_info(
     println!("\nSummary:");
     println!("Total Blocks: {total_blocks}");
     println!("Total Extrinsics: {total_extrinsics}");
-    println!("sTPS - Standard Transaction per Second");
     let diff = time_diff.unwrap_or_else(|| {
-        // block build time in milliseconds
-        let default = 12000;
-        println!("Could not calculate block build time, assuming {default}");
+        // default block build time
+        let default = 12.0;
+        println!("Warning: Could not calculate block build time, assuming {default}");
         default
     });
+    println!("Block Build Time: {diff}");
+    println!("sTPS - Standard Transaction per Second");
     println!(
         "sTPS: {}",
-        total_extrinsics as f64 / (total_blocks as f64 * diff as f64 / 1000.0)
+        total_extrinsics as f64 / (total_blocks as f64 * diff)
     );
     Ok(())
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -87,7 +87,7 @@ pub async fn print_block_info(
     let diff = time_diff.unwrap_or_else(|| {
         // block build time in milliseconds
         let default = 12000;
-        println!("Could not calculate blocks assuming, {default}");
+        println!("Could not calculate block build time, assuming {default}");
         default
     });
     println!(

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -42,7 +42,6 @@ where
             let stats = block_stats.lock().unwrap().try_next().await?.unwrap();
             tracing::debug!("{stats:?}");
             let (time_stamp, hashes) = get_block_details(stats.hash).await?;
-
             let mut remaining_hashes = remaining_hashes.lock().unwrap();
             for xt in &hashes {
                 remaining_hashes.remove(xt);

--- a/src/wasm/runner.rs
+++ b/src/wasm/runner.rs
@@ -249,7 +249,7 @@ impl BenchRunner {
         let remaining_hashes: std::collections::HashSet<Hash> = tx_hashes.iter().cloned().collect();
 
         let wait_for_txs = crate::collect_block_stats(block_stats, remaining_hashes, |hash| {
-            let client: OnlineClient<DefaultConfig> = self.api.client.clone();
+            let client = self.api.client.clone();
             Self::get_block_details(client, hash)
         });
 

--- a/src/wasm/runner.rs
+++ b/src/wasm/runner.rs
@@ -164,10 +164,10 @@ impl BenchRunner {
         ))
     }
 
-    async fn get_extrinsics_hashes_in_block(
+    async fn get_block_details(
         client: OnlineClient<DefaultConfig>,
         block_hash: sp_core::H256,
-    ) -> color_eyre::Result<Vec<sp_core::H256>> {
+    ) -> color_eyre::Result<(u64, Vec<sp_core::H256>)> {
         let block = client.blocks().at(block_hash).await;
         let hashes = block
             .unwrap_or_else(|_| panic!("block {} not found", block_hash))
@@ -178,13 +178,6 @@ impl BenchRunner {
             .map(|e| e.unwrap_or_else(|_| panic!("extrinsic error at block {}", block_hash)))
             .map(|e| BlakeTwo256::hash_of(&e.bytes()))
             .collect();
-        Ok(hashes)
-    }
-
-    async fn get_block_time_stamp(
-        client: OnlineClient<DefaultConfig>,
-        block_hash: sp_core::H256,
-    ) -> color_eyre::Result<u64> {
         let storage_timestamp_storage_addr = api::storage().timestamp().now();
         let time_stamp = client
             .storage()
@@ -192,7 +185,7 @@ impl BenchRunner {
             .fetch(&storage_timestamp_storage_addr)
             .await?
             .unwrap();
-        Ok(time_stamp)
+        Ok((time_stamp, hashes))
     }
 
     /// Call each contract instance `call_count` times. Wait for all txs to be included in a block
@@ -255,18 +248,10 @@ impl BenchRunner {
 
         let remaining_hashes: std::collections::HashSet<Hash> = tx_hashes.iter().cloned().collect();
 
-        let wait_for_txs = crate::collect_block_stats(
-            block_stats,
-            remaining_hashes,
-            |hash| {
-                let client: OnlineClient<DefaultConfig> = self.api.client.clone();
-                Self::get_extrinsics_hashes_in_block(client, hash)
-            },
-            |hash| {
-                let client: OnlineClient<DefaultConfig> = self.api.client.clone();
-                Self::get_block_time_stamp(client, hash)
-            },
-        );
+        let wait_for_txs = crate::collect_block_stats(block_stats, remaining_hashes, |hash| {
+            let client: OnlineClient<DefaultConfig> = self.api.client.clone();
+            Self::get_block_details(client, hash)
+        });
 
         Ok(wait_for_txs)
     }


### PR DESCRIPTION
Change the transaction per second calculation. Previously, it assumed a 0.5-second execution time per block. Now, it takes into account the block build time, which depends on the chain configuration and can be either 6 or 12 seconds.