### PR TITLE
ci: Upgrade actions/upload-artifact and actions/download-artifact to v4

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -2,7 +2,7 @@ name: Benchmark of pallet-contracts and pallet-evm
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
   workflow_dispatch:
 
 env:
@@ -30,9 +30,9 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-         sparse-checkout: |
-          launch/moonbeam.patch
-         sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            launch/moonbeam.patch
+          sparse-checkout-cone-mode: false
 
       - name: Download Moonbeam Release
         run: |
@@ -58,7 +58,7 @@ jobs:
         with:
           args: /bin/bash -c "cd moonbeam_release/*/ && cargo build --release"
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ env.MOONBEAM_ARTIFACT }}
           path: |
@@ -82,7 +82,7 @@ jobs:
       - name: Cache
         uses: Swatinem/rust-cache@v2
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: ${{ env.MOONBEAM_ARTIFACT }}
           path: ./${{ env.MOONBEAM_DIR }}
@@ -113,13 +113,13 @@ jobs:
         id: ink_version
         uses: ./.github/actions/get-contract-language
         with:
-          contracts-directory: './contracts/ink'
+          contracts-directory: "./contracts/ink"
 
       - name: Get Solang contract language verision
         id: solang_version
         uses: ./.github/actions/get-contract-language
         with:
-          contracts-directory: './contracts/solidity/wasm'
+          contracts-directory: "./contracts/solidity/wasm"
 
       - name: Get Solc contract language verision
         id: solc_version
@@ -195,7 +195,7 @@ jobs:
           ${{ matrix.contract }}, ${{ steps.run_smart_bench.outputs.tps }}, ${{ steps.solc_version.outputs.language }}, \
           ${{ env.TEST_PARAMS }}" > ${BENCHMARK_DIR}/${BENCHMARK_FILE}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ env.BENCHMARK_FILE }}
           path: ${{ env.BENCHMARK_DIR }}/${{ env.BENCHMARK_FILE }}
@@ -209,7 +209,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: ${{ env.BENCHMARK_DIR }}
 


### PR DESCRIPTION
Artifact actions v3 will be deprecated by December 5, 2024, updating them.

cc https://github.com/paritytech/ci_cd/issues/1078